### PR TITLE
[IGNORE]Fix duplicate model generation

### DIFF
--- a/laiser/llm_methods.py
+++ b/laiser/llm_methods.py
@@ -213,10 +213,12 @@ def get_completion(input_text, text_columns, input_type, model, tokenizer) -> st
     model_inputs = encodeds.to(device)
     
     with torch.no_grad():
-        generated_ids = model.generate(**model_inputs, max_new_tokens=1000, do_sample=True, pad_token_id=tokenizer.eos_token_id)
-
-
-    generated_ids = model.generate(**model_inputs, max_new_tokens=1000, do_sample=True, pad_token_id=tokenizer.eos_token_id)
+        generated_ids = model.generate(
+            **model_inputs,
+            max_new_tokens=1000,
+            do_sample=True,
+            pad_token_id=tokenizer.eos_token_id,
+        )
     decoded = tokenizer.decode(generated_ids[0], skip_special_tokens=False)
     response = decoded.split("<start_of_turn>model<eos>")[-1].strip()
     processed_response = fetch_model_output(response)


### PR DESCRIPTION
## Summary
- remove the redundant call to `model.generate` in `get_completion`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603b542af083208320674f4871ecbe